### PR TITLE
Add missing quotes in substr expression

### DIFF
--- a/bin/git-extras
+++ b/bin/git-extras
@@ -39,9 +39,9 @@ case "$1" in
     ;;
   update)
     platform=$(uname -s)
-    if [ $(expr substr "$platform" 1 9) = "CYGWIN_NT" ] || \
-      [ $(expr substr "$platform" 1 10) = "MINGW32_NT" ] || \
-      [ $(expr substr "$platform" 1 10) = "MINGW64_NT" ]
+    if [ "$(expr substr "$platform" 1 9)" = "CYGWIN_NT" ] || \
+      [ "$(expr substr "$platform" 1 10)" = "MINGW32_NT" ] || \
+      [ "$(expr substr "$platform" 1 10)" = "MINGW64_NT" ]
     then
       updateForWindows
     else


### PR DESCRIPTION
I ran into the following error message when I executed the command `git extras update`.  The reason are missing quotes for the substr expresion:

cp -f man/git-*.1 /home/jceb/.local/share/man/man1
cp -f etc/bash_completion.sh /home/jceb/.local/etc/bash_completion.d/git-extras
... updated git-extras 4.1.0-dev -> 4.0.0
/home/jceb/.local/bin/git-extras: line 66: unexpected EOF while looking for matching `"'
/home/jceb/.local/bin/git-extras: line 77: syntax error: unexpected end of file
